### PR TITLE
fix: Fixing typo bug for ADFStatus

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-atlassian_doc_builder==0.4
+atlassian_doc_builder==0.5.1
 jira==3.8.0
 mergedeep==1.3.4
 python_json_config==1.2.3


### PR DESCRIPTION
We have found a typo in the library, which breaks the `ADFStatus` object.
The latest patch has been pushed to PyPi. Let's bump the version of the library.

The issue for reference:
https://github.com/khwong-c/atlassian-doc-builder/issues/4